### PR TITLE
migrate custom visibility categories, migrate restricted objects

### DIFF
--- a/scrivito_import_export/scrivito_export.rb
+++ b/scrivito_import_export/scrivito_export.rb
@@ -12,6 +12,14 @@ class ScrivitoExport
     raise "file '#{dir_name}' exists" if File.exist?(dir_name)
     FileUtils.mkdir_p(dir_name)
 
+    custom_visibility_categories = api.get("visibility_categories")["results"]
+
+    if custom_visibility_categories.any? 
+      File.open(File.join(dir_name, "custom_visibility_categories.json"), "w") do |file|
+        file.write(JSON.generate(custom_visibility_categories))
+      end
+    end
+
     obj_count = 0
     File.open(File.join(dir_name, "objs.json"), "w") do |file|
       rev_id, obj_ids = get_obj_ids(api)

--- a/scrivito_import_export/scrivito_export.rb
+++ b/scrivito_import_export/scrivito_export.rb
@@ -12,7 +12,8 @@ class ScrivitoExport
     raise "file '#{dir_name}' exists" if File.exist?(dir_name)
     FileUtils.mkdir_p(dir_name)
 
-    custom_visibility_categories = api.get("visibility_categories")["results"]
+    visibility_categories_response = api.get("visibility_categories") || {}
+    custom_visibility_categories = visibility_categories_response["results"] || []
 
     if custom_visibility_categories.any? 
       File.open(File.join(dir_name, "custom_visibility_categories.json"), "w") do |file|

--- a/scrivito_import_export/scrivito_export.rb
+++ b/scrivito_import_export/scrivito_export.rb
@@ -13,9 +13,9 @@ class ScrivitoExport
     FileUtils.mkdir_p(dir_name)
 
     visibility_categories_response = api.get("visibility_categories") || {}
-    custom_visibility_categories = visibility_categories_response["results"] || []
+    custom_visibility_categories = visibility_categories_response.fetch("results")
 
-    if custom_visibility_categories.any? 
+    if custom_visibility_categories.present? 
       File.open(File.join(dir_name, "custom_visibility_categories.json"), "w") do |file|
         file.write(JSON.generate(custom_visibility_categories))
       end

--- a/scrivito_import_export/scrivito_import.rb
+++ b/scrivito_import_export/scrivito_import.rb
@@ -95,26 +95,25 @@ class ScrivitoImport
   def import_visibility_categories_and_generate_mapping(api, dir_name)
     visibility_categories_ids_mapping = {}
     custom_visibility_categories_file = File.join(dir_name, "custom_visibility_categories.json")
-    if (File.exist?(custom_visibility_categories_file))
+    if File.exist?(custom_visibility_categories_file)
       custom_visibility_categories = JSON.parse(File.read(custom_visibility_categories_file))
       custom_visibility_categories.each do |visibility_category|
-        response = api.post("visibility_categories", {
-          "groups" => visibility_category["groups"], 
-          "title" => visibility_category["title"],
-          "description" => visibility_category["description"],
-          })
+        response = api.post(
+          "visibility_categories", 
+          visibility_category.slice("groups", "title", "description")
+        )
         original_visibility_category_id = visibility_category["id"]
         visibility_categories_ids_mapping[original_visibility_category_id] = response["id"]
       end
     end
-    visibility_categories_ids_mapping
+    visibility_categories_ids_mapping.presence
   end
 
   def update_restriction(restriction_attribute, visibility_categories_ids_mapping)
-    return if restriction_attribute.nil? || restriction_attribute.empty?
+    return if !restriction_attribute.present?
 
-    restriction_attribute.map! do |restriction_id|
-      visibility_categories_ids_mapping[restriction_id] || restriction_id
+    return restriction_attribute.map do |restriction_id|
+      visibility_categories_ids_mapping.fetch(restriction_id) { restriction_id }
     end
   end
 end

--- a/scrivito_import_export/scrivito_import.rb
+++ b/scrivito_import_export/scrivito_import.rb
@@ -23,7 +23,7 @@ class ScrivitoImport
       obj = JSON.load(line)
       puts("[##{line_num}] Creating obj: #{obj['_obj_class']} #{obj['_path']}")
       attrs = import_attrs(api, obj, dir_name)
-      update_restriction(attrs["_restriction"], visibility_categories_ids_mapping)
+      update_restriction(attrs, visibility_categories_ids_mapping)
       retry_command { api.post("workspaces/#{workspace_id}/objs", "obj" => attrs) }
     end
 
@@ -109,12 +109,15 @@ class ScrivitoImport
     visibility_categories_ids_mapping.presence
   end
 
-  def update_restriction(restriction_attribute, visibility_categories_ids_mapping)
+  def update_restriction(attrs, visibility_categories_ids_mapping)
+    restriction_attribute = attrs["_restriction"]
     return if !restriction_attribute.present?
 
-    return restriction_attribute.map do |restriction_id|
+    updated_restriction = restriction_attribute.map do |restriction_id|
       visibility_categories_ids_mapping.fetch(restriction_id) { restriction_id }
     end
+
+    attrs["_restriction"] = updated_restriction
   end
 end
 


### PR DESCRIPTION
Hello @thomasritz . Lately we've faced the problem with migrating production content from one of the Siemens tenants into a newly created UAT tenant. Restricted objects making use of custom visibility categories could not be migrated. Please have a look if it makes sense to include this custom visibility categories migration in the main migration script. Also workflows and teams are candidates to be migrated in a similar fashion but these are not "part of" the actual content.